### PR TITLE
Use brickhub.dev to simplify install

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -36,7 +36,7 @@ cd static_scaffolding
 # 📚 Add the dependencies and initialise mason
 flutter pub add equatable uuid flutter_bloc
 mason init
-mason add scaffolding --git-url https://github.com/sjhorn/mason_bricks --git-path bricks/scaffolding
+mason add scaffolding
 
 # 🚀 scaffold your app
 mason make scaffolding --package static_scaffolding --feature contact \

--- a/docs/static-scaffolding/installing.md
+++ b/docs/static-scaffolding/installing.md
@@ -117,10 +117,7 @@ We will follow the format of the last four lines of `mason.yaml` but remove the 
 The last four lines of `mason.yaml` should now look like:
 ```yaml
 bricks:
-  scaffolding:
-      git:
-        url: https://github.com/sjhorn/mason_bricks
-        path: bricks/scaffolding
+  scaffolding: ^0.0.2 
 ```
 
 Afterwards you can get the brick by running
@@ -134,8 +131,7 @@ You could also have run the following from the command line to achieve the same:
 
 ```sh
 # 🧱 Add scaffolding brick to your mason config
-mason add scaffolding --git-url https://github.com/sjhorn/mason_bricks \
-    --git-path bricks/scaffolding
+mason add scaffolding
 ```
 
 🎈 Your brick is now installed 

--- a/docs/static-scaffolding/scaffolding-home-tests.md
+++ b/docs/static-scaffolding/scaffolding-home-tests.md
@@ -11,9 +11,7 @@ So to add test to many features from the previous example we would first add the
 
 ```sh
 # 🏠 add the scaffolding_home_test brick
-mason add scaffolding_home_test \
-    --git-url https://github.com/sjhorn/mason_bricks \
-    --git-path bricks/scaffolding_home_test
+mason add scaffolding_home_test
 ```
 
 and then running with the same parameters as scaffolding_home_test

--- a/docs/static-scaffolding/scaffolding-home.md
+++ b/docs/static-scaffolding/scaffolding-home.md
@@ -21,9 +21,7 @@ To do this lets add the brick on our project.
 
 ```sh
 # 🏠 add the scaffolding_home brick
-mason add scaffolding_home \
-    --git-url https://github.com/sjhorn/mason_bricks \
-    --git-path bricks/scaffolding_home
+mason add scaffolding_home 
 ```
 
 ## Making more than one feature


### PR DESCRIPTION
We have now been approved for the public beta on brickhub.dev for mason so we have published and can use the bricks from there